### PR TITLE
Add CLI tool to generate manual reports

### DIFF
--- a/automate
+++ b/automate
@@ -1,1 +1,114 @@
+#!/usr/bin/env python3
+"""Generate a structured manual report from CLI arguments or interactive prompts."""
 
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+import sys
+
+SECTIONS = [
+    ("report_date", "Report date"),
+    ("author", "Author"),
+    ("project", "Project"),
+    ("summary", "Summary"),
+    ("work_completed", "Work completed"),
+    ("issues", "Issues / blockers"),
+    ("next_steps", "Next steps"),
+]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Automate the creation of a manual status report."
+    )
+    parser.add_argument("--output", "-o", help="Write the report to a file instead of stdout.")
+    parser.add_argument("--interactive", "-i", action="store_true", help="Prompt for missing values.")
+
+    for field, label in SECTIONS:
+        parser.add_argument(f"--{field.replace('_', '-')}", dest=field, help=f"{label} text.")
+
+    return parser
+
+
+def prompt(label: str, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    value = input(f"{label}{suffix}: ").strip()
+    return value or default
+
+
+def collect_values(args: argparse.Namespace) -> dict[str, str]:
+    values = {
+        "report_date": args.report_date or str(date.today()),
+        "author": args.author or "",
+        "project": args.project or "",
+        "summary": args.summary or "",
+        "work_completed": args.work_completed or "",
+        "issues": args.issues or "None",
+        "next_steps": args.next_steps or "",
+    }
+
+    if args.interactive:
+        for field, label in SECTIONS:
+            values[field] = prompt(label, values[field])
+
+    return values
+
+
+def render_report(values: dict[str, str]) -> str:
+    return "\n".join(
+        [
+            "MANUAL REPORT",
+            "=============",
+            f"Date: {values['report_date']}",
+            f"Author: {values['author'] or 'N/A'}",
+            f"Project: {values['project'] or 'N/A'}",
+            "",
+            "Summary",
+            "-------",
+            values["summary"] or "N/A",
+            "",
+            "Work Completed",
+            "--------------",
+            values["work_completed"] or "N/A",
+            "",
+            "Issues / Blockers",
+            "-----------------",
+            values["issues"] or "None",
+            "",
+            "Next Steps",
+            "----------",
+            values["next_steps"] or "N/A",
+            "",
+        ]
+    )
+
+
+def write_report(report: str, output_path: str | None) -> None:
+    if not output_path:
+        print(report)
+        return
+
+    path = Path(output_path)
+    path.write_text(report + "\n", encoding="utf-8")
+    print(f"Report written to {path}")
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    values = collect_values(args)
+
+    if not args.interactive and not any(
+        getattr(args, field) for field, _ in SECTIONS if field != "report_date"
+    ):
+        parser.error("provide report details via flags or use --interactive")
+
+    report = render_report(values)
+    write_report(report, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a usable implementation in place of the empty `automate` placeholder so maintainers can quickly produce structured manual reports from the repository.
- Allow generating reports non-interactively from scripts or interactively via prompts for ad-hoc use.

### Description
- Add an executable Python CLI `automate` that builds a report from command-line flags or interactive prompts using `argparse` and a `SECTIONS` definition.
- Implement `collect_values`, `prompt`, `render_report`, and `write_report` helpers to gather inputs, format a consistent "MANUAL REPORT" text block, and either print to stdout or write to a file.
- Enforce basic validation so the script errors unless content is supplied via flags or `--interactive`, and include a shebang to make the file runnable.

### Testing
- Successfully compiled the script with `python3 -m py_compile automate`.
- Executed the script with flags using `./automate --author "Alex" --project "VATS" --summary "Drafted weekly report" --work-completed "Collected metrics and prepared updates" --issues "Waiting on finance numbers" --next-steps "Finalize and send"`, which produced the expected report text to stdout and when used with `--output` wrote the report file; both runs succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e21b14548328b7d950926d85deae)